### PR TITLE
Support Erlang/OTP 29 builds

### DIFF
--- a/.github/workflows/hex-publish.yml
+++ b/.github/workflows/hex-publish.yml
@@ -3,18 +3,17 @@ name: Hex Publish
 on:
   push:
     tags:
-    - '*'
-  
+      - "*"
+
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Publish to Hex.pm
-        uses: erlangpack/github-action@v1
+        uses: erlangpack/github-action@v4
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: Test
 on:
   pull_request:
     branches:
-      - 'main'
+      - "main"
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   linux:
@@ -15,36 +15,47 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [25, 26, 27]
+        # support for 26 ended 2026-04-26
+        # https://endoflife.date/erlang
+        otp_version: [27, 28, 29]
         os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Compile
-      run: rebar3 compile
-    - name: Check format
-      run: rebar3 as test fmt -c
-    - name: Unit tests
-      run: rebar3 as test eunit
-    - name: Proper tests
-      run: rebar3 as test proper
+      - uses: actions/checkout@v6
+
+      - name: Compile
+        run: rebar3 compile
+
+      - name: Check format
+        run: rebar3 as test fmt -c
+
+      - name: Unit tests
+        run: rebar3 as test eunit
+
+      - name: Proper tests
+        run: rebar3 as test proper
 
   macos:
     name: Test on MacOS
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Erlang and rebar3
-      run: brew install erlang rebar3
-    - name: Compile
-      run: rebar3 compile
-    - name: Check format
-      run: rebar3 as test fmt -c
-    - name: Unit tests
-      run: rebar3 as test eunit
-    - name: Proper tests
-      run: rebar3 as test proper
+      - uses: actions/checkout@v6
+
+      - name: Install Erlang and rebar3
+        run: brew install erlang rebar3
+
+      - name: Compile
+        run: rebar3 compile
+
+      - name: Check format
+        run: rebar3 as test fmt -c
+
+      - name: Unit tests
+        run: rebar3 as test eunit
+
+      - name: Proper tests
+        run: rebar3 as test proper

--- a/README.md
+++ b/README.md
@@ -1,35 +1,37 @@
-Erlang NIF for scrypt
-=====================
+# Erlang NIF for scrypt
 
-[![Build Status](https://github.com/kpy3/erlscrypt/workflows/Test/badge.svg)](https://github.com/kpy3/erlscrypt/actions?query=branch%3Amaster+workflow%3A"Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-25.0%20to%2027.0-blue)](http://www.erlang.org)
-
+[![Build Status](https://github.com/kpy3/erlscrypt/workflows/Test/badge.svg)](https://github.com/kpy3/erlscrypt/actions?query=branch%main+workflow%3A"Test") [![Erlang Versions](https://img.shields.io/badge/Supported%20Erlang%2FOTP-27.0%20to%2029.0-blue)](http://www.erlang.org)
 
 An Erlang NIF for Colin Percival's "scrypt" function. It uses dirty CPU schedulers for
-generating hash, leaving main schedulers for Erlang applications.   
+generating hash, leaving main schedulers for Erlang applications.
 
 General information about scrypt can be found in [these slides (PDF)](http://www.tarsnap.com/scrypt/scrypt-slides.pdf)
 and [Colin Percival's page on scrypt](http://www.tarsnap.com/scrypt.html).
 
 This library uses code from scrypt [1.3.1](https://github.com/Tarsnap/scrypt/tree/1.3.1).
 
-Using the library
------
-Add library as dependency in `rebar.config` 
+## Using the library
 
-    {deps, [
-        {erlscrypt, "1.0.0"}
-        ...
-    ]}.
+Add library as dependency in `rebar.config`
+
+```erlang
+{deps, [
+    {erlscrypt, "1.0.0"}
+    ...
+]}.
+```
 
 Add `scrypt` as application dependency
 
-    {application, app,
-         [
-          {applications, [
-                          ...
-                          scrypt
-                         ]},
-          ...
-         ]}. 
+```erlang
+{application, app,
+  [
+   {applications, [
+                   ...
+                   scrypt
+                  ]},
+   ...
+  ]}.
+```
 
 Use `scrypt:scrypt/6` for encrypting data.

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,9 +5,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 
 PROJECT := scrypt
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval 'io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]), halt().')
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval 'io:format("~s", [code:lib_dir(erl_interface, include)]), halt().')
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval 'io:format("~s", [code:lib_dir(erl_interface, lib)]), halt().')
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
         {plugins, [erlfmt, rebar3_proper]},
         {deps, [
             %% hex
-            {proper, "1.4.0"}
+            {proper, "1.5.0"}
         ]}
     ]}
 ]}.


### PR DESCRIPTION
## Summary

- fix native include/lib path discovery on Erlang/OTP 29 by using `~s` in the Makefile `erl -eval` expressions
- update CI and docs to cover Erlang/OTP 27, 28, and 29

## Root cause

OTP 29 rejects the old `~ts` formatting expressions used by `c_src/Makefile`, so the shell commands returned no usable include paths. The native compiler then ran without the ERTS include directory and failed to find `erl_nif.h`.

## Validation

- `nix shell nixpkgs#erlang_29 nixpkgs#gcc --command make -C c_src -B V=1`
- `nix shell nixpkgs#erlang_28 nixpkgs#gcc --command make -C c_src -B V=1`
- `nix shell nixpkgs#erlang_27 nixpkgs#gcc --command make -C c_src -B V=1`
- OTP 29 smoke test loaded the NIF and produced the expected 64-byte scrypt vector

Fixes #9
